### PR TITLE
Fixed warning (incorrect disabled source check).

### DIFF
--- a/path_alias_force.module
+++ b/path_alias_force.module
@@ -45,7 +45,7 @@ function _path_alias_force_path_changed($path) {
     return;
   }
   $disabled_sources = drupal_static('path_alias_force_disabled_sources', array());
-  if (isset($disabled_sources[$path])) {
+  if (isset($disabled_sources[$path['source']])) {
     return;
   }
 


### PR DESCRIPTION
The PHP warning 'Illegal offset type in isset or empty path_alias_force.module:48' is thrown every time a node is saved, because $path in the changed line in this PR is an array (and is even documented as such!). If I've understood correctly, this was probably intended to be the path source.

I'm surprised to see this issue, as it suggests the code hasn't been tested in the wild, despite being featured on your www.amazeelabs.com/en/blog/total-language-fallback article ?